### PR TITLE
Feature: Database Schema Edit

### DIFF
--- a/web/prisma/migrations/20250723094858_edit_cashier_store_tables/migration.sql
+++ b/web/prisma/migrations/20250723094858_edit_cashier_store_tables/migration.sql
@@ -1,0 +1,96 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Cashier` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the column `cashierId` on the `Product` table. All the data in the column will be lost.
+  - You are about to drop the column `cashierId` on the `Receipt` table. All the data in the column will be lost.
+  - The primary key for the `TransactionItem` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `transactionId` on the `TransactionItem` table. All the data in the column will be lost.
+  - Added the required column `employeeId` to the `Product` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `employeeId` to the `Receipt` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `storeType` to the `Store` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `receiptId` to the `TransactionItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "Cashier";
+PRAGMA foreign_keys=on;
+
+-- CreateTable
+CREATE TABLE "Employee" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "storeId" TEXT NOT NULL,
+    "pin" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Employee_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "Store" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Product" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "price" DECIMAL NOT NULL,
+    "employeeId" TEXT NOT NULL,
+    "stock" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Product_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "Employee" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Product" ("createdAt", "id", "imageUrl", "name", "price", "stock", "updatedAt") SELECT "createdAt", "id", "imageUrl", "name", "price", "stock", "updatedAt" FROM "Product";
+DROP TABLE "Product";
+ALTER TABLE "new_Product" RENAME TO "Product";
+CREATE TABLE "new_Receipt" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "dateTime" DATETIME NOT NULL,
+    "printedAt" DATETIME,
+    "employeeId" TEXT NOT NULL,
+    "cashReceived" REAL NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Receipt_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "Employee" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Receipt" ("cashReceived", "createdAt", "dateTime", "id", "updatedAt") SELECT "cashReceived", "createdAt", "dateTime", "id", "updatedAt" FROM "Receipt";
+DROP TABLE "Receipt";
+ALTER TABLE "new_Receipt" RENAME TO "Receipt";
+CREATE TABLE "new_Store" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "address" TEXT,
+    "number" TEXT,
+    "logoUrl" TEXT,
+    "tagline" TEXT,
+    "regTin" TEXT,
+    "permitNumber" TEXT,
+    "storeType" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Store_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Store" ("createdAt", "id", "name", "updatedAt", "userId") SELECT "createdAt", "id", "name", "updatedAt", "userId" FROM "Store";
+DROP TABLE "Store";
+ALTER TABLE "new_Store" RENAME TO "Store";
+CREATE TABLE "new_TransactionItem" (
+    "productId" TEXT NOT NULL,
+    "receiptId" TEXT NOT NULL,
+    "price" DECIMAL NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+
+    PRIMARY KEY ("productId", "receiptId"),
+    CONSTRAINT "TransactionItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "TransactionItem_receiptId_fkey" FOREIGN KEY ("receiptId") REFERENCES "Receipt" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_TransactionItem" ("createdAt", "price", "productId", "quantity", "updatedAt") SELECT "createdAt", "price", "productId", "quantity", "updatedAt" FROM "TransactionItem";
+DROP TABLE "TransactionItem";
+ALTER TABLE "new_TransactionItem" RENAME TO "TransactionItem";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -7,6 +7,17 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  admin
+  cashier
+}
+
+enum StoreType {
+  restaurant
+  cafe
+  salon
+}
+
 model User {
   id    String @id @default(uuid())
   name  String
@@ -25,24 +36,33 @@ model User {
 }
 
 model Store {
-  id     String @id @default(uuid())
-  name   String
-  userId String
+  id           String @id @default(uuid())
+  name         String
+  userId       String
+  address      String?
+  number       String?
+  logoUrl      String?
+  tagline      String?
+  regTin       String?
+  permitNumber String?
 
-  user     User      @relation(fields: [userId], references: [id])
-  cashiers Cashier[]
+  storeType StoreType
+  user      User      @relation(fields: [userId], references: [id])
+  employee  Employee[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
 
-model Cashier {
+model Employee {
   id      String @id @default(uuid())
   name    String
   storeId String
-
+  pin     String
+  
+  role         Role 
   store        Store         @relation(fields: [storeId], references: [id])
-  transactions Receipt[]
+  receipts     Receipt[]
   products     Product[]
 
   createdAt DateTime @default(now())
@@ -52,10 +72,11 @@ model Cashier {
 model Receipt {
   id            String   @id @default(uuid())
   dateTime      DateTime
-  cashierId     String
+  printedAt     DateTime?
+  employeeId    String
   cashReceived  Float
 
-  cashier          Cashier           @relation(fields: [cashierId], references: [id])
+  employee         Employee           @relation(fields: [employeeId], references: [id])
   transactionItems TransactionItem[]
 
   createdAt DateTime @default(now())
@@ -63,14 +84,14 @@ model Receipt {
 }
 
 model Product {
-  id        String  @id @default(uuid())
-  name      String
-  imageUrl  String?
-  price     Decimal
-  cashierId String
-  stock     Int
+  id          String  @id @default(uuid())
+  name        String
+  imageUrl    String?
+  price       Decimal
+  employeeId  String
+  stock       Int
 
-  cashier          Cashier           @relation(fields: [cashierId], references: [id])
+  employee         Employee           @relation(fields: [employeeId], references: [id])
   transactionItems TransactionItem[]
 
   createdAt DateTime @default(now())
@@ -79,17 +100,17 @@ model Product {
 
 model TransactionItem {
   productId     String
-  transactionId String
+  receiptId     String
   price         Decimal
   quantity      Int
 
   product     Product     @relation(fields: [productId], references: [id])
-  transaction Receipt @relation(fields: [transactionId], references: [id])
+  receipt Receipt @relation(fields: [receiptId], references: [id])
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@id([productId, transactionId])
+  @@id([productId, receiptId])
 }
 
 model Session {


### PR DESCRIPTION
**_✨ Add Cashier and Store Table Structures
Changes included:_**
- Added Store model with details like address, logo, permit number, etc.
- Added Employee model with role enum (admin, cashier), and PIN-based access.
- Linked Employee to Store via storeId.

**_Updated Receipt model:_**
- Added employeeId instead of cashier
- Added optional cashReceived and printedAt timestamps.
- Added store-related optional fields (e.g., tagline, regTin) for receipt printing purposes.
- Added enums: Role, StoreType
- Made several fields optional to support initial setup flexibility.

partially resolves (not tagging since need pa ng endpoints)
34 and 34

Purpose:
To support store-specific data, multi-user role access, and receipt printing functionalities.